### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.2.2
+- Fixed variable functions not working with multiple internal BOps.
+- Fixed modular inputs (`originPath: "module"`) flow.
+  - Now all the modular inputs (and its dependencies) are executed on a separated context.
+  - In practice this means they are isolated from the rest of the flow, and only called by other functions.
+
 ## 0.2.1
 - Fixed verification for BOps dependency in BOps.
 - Added logs for when the dependency prop validation fails.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-system",
-  "version": "0.2.1-aaa",
+  "version": "0.2.2",
   "description": "A system to be any system",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-system",
-  "version": "0.2.1",
+  "version": "0.2.1-aaa",
   "description": "A system to be any system",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/bops-functions/bops-engine/contexts/bop-context.ts
+++ b/src/bops-functions/bops-engine/contexts/bop-context.ts
@@ -7,7 +7,7 @@ export class BopContext {
   public readonly constants : ResolvedConstants;
   public readonly variables : ResolvedVariables;
   public readonly config : BopsConfigurationEntry[];
-  public readonly results : Map<number, unknown> = new Map();
+  public readonly resultsCache : Map<number, unknown> = new Map();
   public readonly availableFunctions;
 
   // eslint-disable-next-line max-params

--- a/src/bops-functions/bops-engine/contexts/bop-context.ts
+++ b/src/bops-functions/bops-engine/contexts/bop-context.ts
@@ -1,0 +1,35 @@
+import { BopsConfigurationEntry } from "../../../configuration/business-operations/business-operations-type";
+import { MappedFunctions } from "../modules-manager";
+import { ResolvedConstants } from "../static-info-validation";
+import { ResolvedVariables } from "../variables/variables-context";
+
+export class BopContext {
+  public readonly constants : ResolvedConstants;
+  public readonly variables : ResolvedVariables;
+  public readonly config : BopsConfigurationEntry[];
+  public readonly results : Map<number, unknown> = new Map();
+  public readonly availableFunctions;
+
+  // eslint-disable-next-line max-params
+  public constructor (
+    config : BopsConfigurationEntry[],
+    variables : ResolvedVariables,
+    constants : ResolvedConstants,
+    availableFunctions : MappedFunctions,
+  ) {
+    this.constants = Object.freeze(constants);
+    this.variables = variables;
+    this.config = config;
+    this.availableFunctions = availableFunctions;
+  }
+
+  /** Clones the context, flushing the results */
+  public static cloneToNewContext (bopContext : BopContext) : BopContext {
+    return new BopContext(
+      bopContext.config,
+      bopContext.variables,
+      bopContext.constants,
+      bopContext.availableFunctions,
+    );
+  }
+}

--- a/src/bops-functions/bops-engine/contexts/system-context.ts
+++ b/src/bops-functions/bops-engine/contexts/system-context.ts
@@ -1,0 +1,31 @@
+import { ConfigurationType } from "../../../configuration/configuration-type";
+import { BopsVariable } from "../../../configuration/business-operations/business-operations-type";
+import { MappedFunctions, ModuleManager } from "../modules-manager";
+import { ResolvedConstants, StaticSystemInfo } from "../static-info-validation";
+import { VariableContext } from "../variables/variables-context";
+
+export class SystemContext {
+  public readonly constants : Record<string, ResolvedConstants>;
+  public readonly variables : Record<string, BopsVariable[]>;
+  public readonly moduleManager : ModuleManager;
+  public mappedFunctions ?: MappedFunctions;
+  public readonly config : ConfigurationType;
+
+  public constructor (options : {
+    ModuleManager : ModuleManager;
+    SystemConfig : ConfigurationType;
+  }) {
+    this.constants = StaticSystemInfo.validateSystemStaticInfo(options.SystemConfig);
+    this.variables = VariableContext.validateSystemVariables(options.SystemConfig);
+    this.moduleManager = options.ModuleManager;
+    this.config = options.SystemConfig;
+  }
+
+  public get hasMappedFunctions () : boolean {
+    return this.mappedFunctions !== undefined;
+  }
+
+  public generateMappedFunctions () : void {
+    this.mappedFunctions = this.moduleManager.resolveSystemModules(this.config);
+  }
+}

--- a/src/bops-functions/bops-engine/variables/functions/increase-variable.ts
+++ b/src/bops-functions/bops-engine/variables/functions/increase-variable.ts
@@ -17,7 +17,6 @@ export function increaseVariablesFunction (input : CloudedObject, variables : Re
     }
 
     (foundVariable.value as number) += 1; //input[variableName] as number;
-    console.log(foundVariable.value);
     updatedCount++;
   }
 

--- a/src/bops-functions/bops-engine/variables/functions/increase-variable.ts
+++ b/src/bops-functions/bops-engine/variables/functions/increase-variable.ts
@@ -4,7 +4,7 @@ import { ResolvedVariables } from "../variables-context";
 
 export function increaseVariablesFunction (input : CloudedObject, variables : ResolvedVariables) : unknown {
   let updatedCount = 0;
-  console.log(input, variables);
+
   for(const variableName of Object.keys(input)) {
     const foundVariable = variables[variableName];
 
@@ -17,9 +17,10 @@ export function increaseVariablesFunction (input : CloudedObject, variables : Re
     }
 
     (foundVariable.value as number) += 1; //input[variableName] as number;
+    console.log(foundVariable.value);
     updatedCount++;
   }
-  console.log(updatedCount);
+
   return { updatedCount };
 }
 

--- a/src/bops-functions/bops-engine/variables/functions/increase-variable.ts
+++ b/src/bops-functions/bops-engine/variables/functions/increase-variable.ts
@@ -4,20 +4,22 @@ import { ResolvedVariables } from "../variables-context";
 
 export function increaseVariablesFunction (input : CloudedObject, variables : ResolvedVariables) : unknown {
   let updatedCount = 0;
+  console.log(input, variables);
   for(const variableName of Object.keys(input)) {
     const foundVariable = variables[variableName];
 
     if(foundVariable === undefined) {
-      return { errorMessage: `No variable named "${input.variableName}" was found` };
+      return { errorMessage: `No variable named "${variableName}" was found` };
     }
 
     if(typeof  input[variableName] !== "number" || foundVariable.type !== "number") {
       return { errorMessage: `Input value ${input[variableName]} is not a number` };
     }
 
-    (foundVariable.value as number) += input[variableName] as number;
+    (foundVariable.value as number) += 1; //input[variableName] as number;
     updatedCount++;
   }
+  console.log(updatedCount);
   return { updatedCount };
 }
 

--- a/src/bops-functions/bops-engine/variables/variables-context.ts
+++ b/src/bops-functions/bops-engine/variables/variables-context.ts
@@ -61,11 +61,8 @@ export class VariableContext {
   ];
 
   private wrapVariables (varFunction : Function) : Function {
-    console.log("wraping", varFunction.name, "with", Object.keys(this.variables));
     const resultFunction = (inputs : unknown) : unknown => {
-      console.log("Running var fun", varFunction.name, this.variables);
       const res = varFunction(inputs, this.variables);
-      console.log(res);
       return res;
     };
     return resultFunction;

--- a/src/bops-functions/bops-engine/variables/variables-context.ts
+++ b/src/bops-functions/bops-engine/variables/variables-context.ts
@@ -22,7 +22,7 @@ export class VariableContext {
   public static validateSystemVariables (systemConfig : ConfigurationType) : Record<string, BopsVariable[]> {
     const systemVariables : Record<string, BopsVariable[]> = {};
     for(const bop of systemConfig.businessOperations) {
-      systemVariables[bop.name] = this.validateBopVariables(bop.variables);
+      systemVariables[bop.name] = VariableContext.validateBopVariables(bop.variables);
     }
     return systemVariables;
   }
@@ -50,18 +50,25 @@ export class VariableContext {
   public appendVariableFunctions (functionsMap : MappedFunctions) : MappedFunctions {
     return new Map([
       ...Array.from(functionsMap),
-      ...this.variableFunctions,
+      ...this.getVariableFunctions(),
     ]);
   }
 
-  private variableFunctions : Array<[ModuleFullName<"variable">, Function]> = [
-    ["variable.setVariables", this.wrapVariables(setVariablesFunction)],
+  private getVariableFunctions : () => Array<[ModuleFullName<"variable">, Function]> = () => [
     ["variable.increaseVariables", this.wrapVariables(increaseVariablesFunction)],
+    ["variable.setVariables", this.wrapVariables(setVariablesFunction)],
     ["variable.decreaseVariables", this.wrapVariables(decreaseVariablesFunction)],
   ];
 
   private wrapVariables (varFunction : Function) : Function {
-    return (inputs : unknown) : unknown => varFunction(inputs, this.variables);
+    console.log("wraping", varFunction.name, "with", Object.keys(this.variables));
+    const resultFunction = (inputs : unknown) : unknown => {
+      console.log("Running var fun", varFunction.name, this.variables);
+      const res = varFunction(inputs, this.variables);
+      console.log(res);
+      return res;
+    };
+    return resultFunction;
   }
 
   public static variablesInfo : Map<string, InternalMetaFunction> = new Map([

--- a/src/bops-functions/prebuilt-functions/flux-control/forLoop.ts
+++ b/src/bops-functions/prebuilt-functions/flux-control/forLoop.ts
@@ -1,5 +1,6 @@
 import { InternalMetaFunction } from "../../internal-meta-function";
 
+// eslint-disable-next-line max-lines-per-function
 export const forLoopFunction = async (input : {
   quantity : number;
   module : Function;
@@ -8,13 +9,17 @@ export const forLoopFunction = async (input : {
 }) : Promise<unknown> => {
   if(typeof input.quantity !== "number") return { errorMessage: "property \"quantity\" must be a number" };
 
-  let i : number;
-  for(i = 0; i <= input.quantity-1; i++) {
+  let finalIndex = 0;
+
+  for(let i = 0; i <= input.quantity-1; i++) {
+    console.log(input, i);
     await input.module();
     await input.postEach();
+
+    finalIndex = i;
   }
   await input.postAll();
-  return ({ lastIndexValue: i });
+  return ({ lastIndexValue: finalIndex });
 };
 
 export const forLoopInformation : InternalMetaFunction = {

--- a/src/bops-functions/prebuilt-functions/flux-control/forLoop.ts
+++ b/src/bops-functions/prebuilt-functions/flux-control/forLoop.ts
@@ -13,10 +13,14 @@ export const forLoopFunction = async (input : {
 
   for(let i = 0; i <= input.quantity-1; i++) {
     await input.module();
-    await input.postEach();
+
+    if (input.postEach !== undefined) await input.postEach();
+
     finalIndex = i;
   }
-  await input.postAll();
+
+  if (input.postAll !== undefined) await input?.postAll();
+
   return ({ lastIndexValue: finalIndex });
 };
 

--- a/src/bops-functions/prebuilt-functions/flux-control/forLoop.ts
+++ b/src/bops-functions/prebuilt-functions/flux-control/forLoop.ts
@@ -12,10 +12,8 @@ export const forLoopFunction = async (input : {
   let finalIndex = 0;
 
   for(let i = 0; i <= input.quantity-1; i++) {
-    console.log(input, i);
     await input.module();
     await input.postEach();
-
     finalIndex = i;
   }
   await input.postAll();

--- a/src/configuration/business-operations/cyclic-dependency-check.ts
+++ b/src/configuration/business-operations/cyclic-dependency-check.ts
@@ -11,16 +11,20 @@ export class BopsCyclicDependencyCheck {
     });
   }
 
-  public checkBopDependencyChain (bopsName : string, requireChain : string[] = []) : void {
-    if (requireChain.includes(bopsName)) {
+  public checkBopDependencyChain (
+    initialBopsName : string, requireChain : string[] = [], currentDependencyName ?: string) : void {
+    if (requireChain.includes(initialBopsName)) {
       throw Error("Cannot run a BOp with a cyclic dependecy: " + requireChain.join(", "));
     }
 
-    requireChain.push(bopsName);
+    if (currentDependencyName !== undefined) requireChain.push(currentDependencyName);
 
-    const currentDependencies = this.getBopsDependencies(bopsName);
+    const currentDependencies = this.getBopsDependencies(
+      currentDependencyName === undefined ? initialBopsName : currentDependencyName,
+    );
+
     currentDependencies.forEach((dependency) => {
-      this.checkBopDependencyChain(dependency, requireChain);
+      this.checkBopDependencyChain(initialBopsName, requireChain, dependency);
     });
   }
 

--- a/test/configuration-de-serializer/bops-cyclic-dependency-check.spec.ts
+++ b/test/configuration-de-serializer/bops-cyclic-dependency-check.spec.ts
@@ -3,7 +3,7 @@ const BopsDependencyLoop = require("./test-data/configuration/bops-dependency-lo
 const BopsDependencyNoLoop = require("./test-data/configuration/bops-dependency-no-loop.json");
 import { expect } from "chai";
 
-describe.only("BOps Cyclic Dependency Check", () => {
+describe("BOps Cyclic Dependency Check", () => {
   it("Fails to execute when there is cyclic dependency", () => {
     const checkDependencies = new BopsCyclicDependencyCheck(BopsDependencyLoop["businessOperations"]);
 

--- a/test/configuration-de-serializer/bops-cyclic-dependency-check.spec.ts
+++ b/test/configuration-de-serializer/bops-cyclic-dependency-check.spec.ts
@@ -3,7 +3,7 @@ const BopsDependencyLoop = require("./test-data/configuration/bops-dependency-lo
 const BopsDependencyNoLoop = require("./test-data/configuration/bops-dependency-no-loop.json");
 import { expect } from "chai";
 
-describe("BOps Cyclic Dependency Check", () => {
+describe.only("BOps Cyclic Dependency Check", () => {
   it("Fails to execute when there is cyclic dependency", () => {
     const checkDependencies = new BopsCyclicDependencyCheck(BopsDependencyLoop["businessOperations"]);
 

--- a/test/configuration-de-serializer/test-data/configuration/bops-dependency-no-loop.json
+++ b/test/configuration-de-serializer/test-data/configuration/bops-dependency-no-loop.json
@@ -65,7 +65,18 @@
       "constants": [],
       "variables": [],
       "customObjects": [],
-      "configuration": []
+      "configuration": [
+        {
+          "key": 15,
+          "moduleName": "function-2",
+          "moduleType": "bop",
+          "dependencies": [
+            { "origin": "input", "originPath": "carId", "targetPath": "id" },
+            { "origin": "constants", "originPath": "trueValue", "targetPath": "sold" },
+            { "origin": 16 }
+          ]
+        }
+      ]
     },
     {
       "name": "car-sell",
@@ -208,6 +219,16 @@
         {
           "key": 15,
           "moduleName": "function-2",
+          "moduleType": "bop",
+          "dependencies": [
+            { "origin": "input", "originPath": "carId", "targetPath": "id" },
+            { "origin": "constants", "originPath": "trueValue", "targetPath": "sold" },
+            { "origin": 16 }
+          ]
+        },
+        {
+          "key": 155,
+          "moduleName": "function-3",
           "moduleType": "bop",
           "dependencies": [
             { "origin": "input", "originPath": "carId", "targetPath": "id" },


### PR DESCRIPTION
This PR fixes some problems we had with multiple BOps and their contexts. Also there was a problem with the flow when a Module in the BOps `configuration` was a `"module"` dependency, in which the dependencies were not executed each time such module was called, instead, their response was always cached.

In practice, this bug made for loops have a really odd behavior.