### PR TITLE
v0.3.1 - Improves Control of BOps TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.3.1
+- Improved BOps TTL (Time to Live) Configuration
+  - Each BOp may have a specific ttl value and the default can be set via CLI (`--ttl` or `-T`). Default ttl is 2000 ms.
 ## 0.3.0
 ### File Splitting
 - System `schemas`, `businessOperations`, and `protocols` configuration json can now be split into multiple files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meta-system",
-  "version": "0.3.0-RC4",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "meta-system",
-      "version": "0.3.0-RC4",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
         "@meta-system/meta-function-helper": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-system",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A system to be any system",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/bin/commands.ts
+++ b/src/bin/commands.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from "commander";
 import constants from "../common/constants";
 import { environment } from "../common/execution-env";
+import { parseInteger } from "../common/helpers/parsers";
 import { logLevelsArray } from "../common/logger/logger-types";
 import { testBopFunction, main } from "./functions";
 
@@ -11,6 +12,8 @@ const testBop = new Command("test-bop")
 
 const run = new Command("run")
   .description("Runs the given file")
+  .argument("<config-path>", "The path to your system configuration json")
+  .action(main)
   .option("-d, --debug", "Logs additional info on the execution of BOps", () => {
     environment.silent.constants.logLevel = "debug";
   })
@@ -24,10 +27,13 @@ const run = new Command("run")
       .default(constants.DEFAULT_LOG_LEVEL))
   .addOption(
     new Option("-t, --type-check <level>", "Type checking level")
+      .argParser(parseInteger)
       .choices(["0", "1", "2", "3", "4"])
-      .default("1"))
-  .argument("<config-path>", "The path to your system configuration json")
-  .action(main);
+      .default(1))
+  .addOption(
+    new Option("-T, --ttl, --time-to-live <time>", "Maximum execution time of a BOp in ms")
+      .argParser(parseInteger)
+      .default(2000));
 
 
 export { testBop, run };

--- a/src/bootstrap/function-setup.ts
+++ b/src/bootstrap/function-setup.ts
@@ -14,6 +14,7 @@ import { SchemasManager } from "../schemas/application/schemas-manager";
 import { ModuleType } from "../configuration/business-operations/business-operations-type";
 import { DependencyPropValidator } from "./dependency-validator";
 import { logger } from "../common/logger/logger";
+import { environment } from "../common/execution-env";
 
 export class FunctionSetup {
   private readonly bopsManager = new BopsManagerClass();
@@ -269,7 +270,7 @@ export class FunctionSetup {
 
       this.bopsManager.add(
         bopName,
-        this.bopsEngine.stitch(currentBopConfig),
+        this.bopsEngine.stitch(currentBopConfig, currentBopConfig.ttl ?? environment.constants.ttl),
       );
       bopsBuilt++;
     });

--- a/src/common/helpers/parsers.ts
+++ b/src/common/helpers/parsers.ts
@@ -1,0 +1,6 @@
+export function parseInteger (value : string) : number {
+  const parsedValue = parseInt(value);
+  if(isNaN(parsedValue)) throw Error(`${value} is not a valid integer`);
+  if(Number(value) !== parsedValue) console.warn(`${value} will be truncated to an integer`);
+  return parsedValue;
+}

--- a/src/configuration/assertions/business-operations/is-business-operations.ts
+++ b/src/configuration/assertions/business-operations/is-business-operations.ts
@@ -2,7 +2,7 @@ import { isBopsConstants } from "./is-bops-constants";
 import { isBopsCustomObjects } from "./is-bops-custom-objects";
 import { isBopsConfigurationEntry } from "./is-bops-configuration";
 import { BusinessOperations } from "../../business-operations/business-operations-type";
-import { isType } from "../is-type";
+import { isType, optionalIsType } from "../is-type";
 import { isBopsVariables } from "./is-bops-variables";
 import { isObjectDefinition } from "@meta-system/object-definition";
 
@@ -34,6 +34,7 @@ export function isBusinessOperations (input : unknown) : asserts input is Busine
   const businessOperationInput = input as BusinessOperations;
 
   isType("string", "Business Operation with incorrect format", businessOperationInput.name);
+  optionalIsType("number", `BOp - ${businessOperationInput.name}: TTL must be a number`, businessOperationInput.ttl);
 
   isObjectDefinition(businessOperationInput.input);
   isObjectDefinition(businessOperationInput.output);

--- a/src/configuration/business-operations/business-operation.ts
+++ b/src/configuration/business-operations/business-operation.ts
@@ -22,6 +22,7 @@ export class BusinessOperation implements BusinessOperations {
   public variables : BopsVariable[];
   public configuration : BopsConfigurationEntry[];
   public customObjects : BopsCustomObject[];
+  public ttl ?: number;
 
   public constructor (parameters : BusinessOperations) {
     this.name = parameters.name;
@@ -31,6 +32,7 @@ export class BusinessOperation implements BusinessOperations {
     this.configuration = parameters.configuration;
     this.customObjects = parameters.customObjects;
     this.variables = parameters.variables;
+    this.ttl = parameters.ttl;
   }
 
   // eslint-disable-next-line max-lines-per-function

--- a/src/configuration/business-operations/business-operations-type.ts
+++ b/src/configuration/business-operations/business-operations-type.ts
@@ -2,6 +2,7 @@ import { ObjectDefinition } from "@meta-system/object-definition";
 import { ExtendedJsonTypes } from "../../common/types/json-types";
 
 export interface BusinessOperations {
+  ttl ?: number;
   name : string;
   input : ObjectDefinition;
   output : ObjectDefinition;


### PR DESCRIPTION
## v0.3.1
This minor version improves the control over business operations TTL. Now you may use the `"ttl"` property in the BOp config to set that especific BOP TTL or use the `--ttl` CLI option to set the default TTL for all BOps in ms. By default, the value is 2000 ms.