### PR TITLE
Helper Updates and BOp failure/CWD fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+# 0.3.2
+- Updated meta-protocol-helper and meta-function-helper
+- Fixed system crashing on BOp failure
+- All BOps working directory will now be the install directory (\<System Config Directory\>/runtime)
+  - This prevents BOp modules that use disk operations from installing in a folder that is not the config folder
+
 ## 0.3.1
 - Improved BOps TTL (Time to Live) Configuration
   - Each BOp may have a specific ttl value and the default can be set via CLI (`--ttl` or `-T`). Default ttl is 2000 ms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "meta-system",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "meta-system",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
-        "@meta-system/meta-function-helper": "^0.3.4",
-        "@meta-system/meta-protocol-helper": "^0.3.4",
+        "@meta-system/meta-function-helper": "^0.4.0",
+        "@meta-system/meta-protocol-helper": "^0.4.0",
         "@meta-system/object-definition": "^1.1.4",
         "chalk": "^4.1.2",
         "commander": "^8.3.0",
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@meta-system/meta-function-helper": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@meta-system/meta-function-helper/-/meta-function-helper-0.3.4.tgz",
-      "integrity": "sha512-jtrYyMw7Bl1MfgkXSpfAYoXwAsBg7zXvs4Z/xHYrGLJXM2J+rGJRLL2pfFWTv97zw7wnzG8+y2ipSA9poJmLUw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@meta-system/meta-function-helper/-/meta-function-helper-0.4.0.tgz",
+      "integrity": "sha512-+wCeKqpwdTRiPf8Ufvsr2e04yVZjnurhRkdLWtnVnWU1eN8MCqxpKxmlIrPct/o7JZ2MiOpr0Io80wrxr0FnPw==",
       "dependencies": {
         "@meta-system/object-definition": "^1.1.4",
         "chalk": "^4.1.0",
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@meta-system/meta-protocol-helper": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@meta-system/meta-protocol-helper/-/meta-protocol-helper-0.3.4.tgz",
-      "integrity": "sha512-JeSPW2TUJAl1aHoJ2vTCxSOKcVQuNRp7wseawSR3ZI3NKaQfw3Boq8L6zq/rSPRaslykfHxFuNg83vndMG+akQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@meta-system/meta-protocol-helper/-/meta-protocol-helper-0.4.0.tgz",
+      "integrity": "sha512-QfmLEHqLeGTSgR6lOLgfPX/dhjh2xkRKDEO7Z4iVQKLlH2LDb/cPkQbvm2TJhENJg3nI4h4DYXCg/bWLYJjQ/A==",
       "dependencies": {
         "@meta-system/meta-function-helper": "^0.3.4",
         "@meta-system/object-definition": "^1.1.4",
@@ -628,6 +628,20 @@
       "bin": {
         "db-protocol-check": "dist/src/bin/validate-db-protocol.js",
         "meta-protocol-check": "dist/src/bin/validate-meta-protocol.js"
+      }
+    },
+    "node_modules/@meta-system/meta-protocol-helper/node_modules/@meta-system/meta-function-helper": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@meta-system/meta-function-helper/-/meta-function-helper-0.3.4.tgz",
+      "integrity": "sha512-jtrYyMw7Bl1MfgkXSpfAYoXwAsBg7zXvs4Z/xHYrGLJXM2J+rGJRLL2pfFWTv97zw7wnzG8+y2ipSA9poJmLUw==",
+      "dependencies": {
+        "@meta-system/object-definition": "^1.1.4",
+        "chalk": "^4.1.0",
+        "semver": "^7.3.4"
+      },
+      "bin": {
+        "meta-function-check": "dist/src/bin/validate-repo.js",
+        "meta-package-check": "dist/src/bin/validate-package.js"
       }
     },
     "node_modules/@meta-system/object-definition": {
@@ -6725,9 +6739,9 @@
       "dev": true
     },
     "@meta-system/meta-function-helper": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@meta-system/meta-function-helper/-/meta-function-helper-0.3.4.tgz",
-      "integrity": "sha512-jtrYyMw7Bl1MfgkXSpfAYoXwAsBg7zXvs4Z/xHYrGLJXM2J+rGJRLL2pfFWTv97zw7wnzG8+y2ipSA9poJmLUw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@meta-system/meta-function-helper/-/meta-function-helper-0.4.0.tgz",
+      "integrity": "sha512-+wCeKqpwdTRiPf8Ufvsr2e04yVZjnurhRkdLWtnVnWU1eN8MCqxpKxmlIrPct/o7JZ2MiOpr0Io80wrxr0FnPw==",
       "requires": {
         "@meta-system/object-definition": "^1.1.4",
         "chalk": "^4.1.0",
@@ -6735,15 +6749,27 @@
       }
     },
     "@meta-system/meta-protocol-helper": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@meta-system/meta-protocol-helper/-/meta-protocol-helper-0.3.4.tgz",
-      "integrity": "sha512-JeSPW2TUJAl1aHoJ2vTCxSOKcVQuNRp7wseawSR3ZI3NKaQfw3Boq8L6zq/rSPRaslykfHxFuNg83vndMG+akQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@meta-system/meta-protocol-helper/-/meta-protocol-helper-0.4.0.tgz",
+      "integrity": "sha512-QfmLEHqLeGTSgR6lOLgfPX/dhjh2xkRKDEO7Z4iVQKLlH2LDb/cPkQbvm2TJhENJg3nI4h4DYXCg/bWLYJjQ/A==",
       "requires": {
         "@meta-system/meta-function-helper": "^0.3.4",
         "@meta-system/object-definition": "^1.1.4",
         "chalk": "^4.1.0",
         "deep-diff": "^1.0.2",
         "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "@meta-system/meta-function-helper": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/@meta-system/meta-function-helper/-/meta-function-helper-0.3.4.tgz",
+          "integrity": "sha512-jtrYyMw7Bl1MfgkXSpfAYoXwAsBg7zXvs4Z/xHYrGLJXM2J+rGJRLL2pfFWTv97zw7wnzG8+y2ipSA9poJmLUw==",
+          "requires": {
+            "@meta-system/object-definition": "^1.1.4",
+            "chalk": "^4.1.0",
+            "semver": "^7.3.4"
+          }
+        }
       }
     },
     "@meta-system/object-definition": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-system",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A system to be any system",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -71,8 +71,8 @@
     "url": "https://github.com/mapikit/meta-system/issues"
   },
   "dependencies": {
-    "@meta-system/meta-function-helper": "^0.3.4",
-    "@meta-system/meta-protocol-helper": "^0.3.4",
+    "@meta-system/meta-function-helper": "^0.4.0",
+    "@meta-system/meta-protocol-helper": "^0.4.0",
     "@meta-system/object-definition": "^1.1.4",
     "chalk": "^4.1.2",
     "commander": "^8.3.0",

--- a/src/bin/functions.ts
+++ b/src/bin/functions.ts
@@ -30,6 +30,7 @@ export async function main (fileLocation : string) : Promise<void> {
     runtimeDefaults.defaultInstallFolder);
   if(environment.constants.configPath === undefined) throw chalk.redBright("Config file not found");
   if(environment.constants.saveLog) hookConsoleToFile(`${environment.constants.configDir}/logs`);
+  process.chdir(environment.constants.installDir);
 
   logger.debug(getSystemInfo());
 


### PR DESCRIPTION
This version contains the update of helpers packages, as well as two important fixes:
- System will no longer crash if a bop does
- All BOp processes will now be executed in the runtime dir to prevent disk using packages from using the wrong directory